### PR TITLE
fix: centralize external links and add proper rel attributes for SEO

### DIFF
--- a/src/app/features/docs/pages/contact/contact.html
+++ b/src/app/features/docs/pages/contact/contact.html
@@ -102,7 +102,9 @@
             Pridružite se našem Slack serveru za diskusije, pomoć i saradnju
           </p>
           <a
-            href="https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ"
+            [href]="links.slack"
+            target="_blank"
+            rel="noopener noreferrer nofollow"
             class="inline-flex items-center text-primary-400 hover:text-primary-300 font-medium"
           >
             Pridruži se Slack serveru

--- a/src/app/features/docs/pages/contact/contact.ts
+++ b/src/app/features/docs/pages/contact/contact.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { SeoManager } from '../../../../core/seo/seo-manager';
+import { EXTERNAL_LINKS } from '../../../../shared/external-links';
 
 @Component({
   selector: 'app-contact',
@@ -10,6 +11,7 @@ import { SeoManager } from '../../../../core/seo/seo-manager';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Contact {
+  readonly links = EXTERNAL_LINKS;
   private readonly seo = inject(SeoManager);
 
   constructor() {

--- a/src/app/shared/external-links.ts
+++ b/src/app/shared/external-links.ts
@@ -1,0 +1,6 @@
+export const EXTERNAL_LINKS = {
+  slack:
+    'https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ',
+  github: 'https://github.com/pushserbia',
+  linkedin: 'https://www.linkedin.com/company/pushserbia',
+} as const;

--- a/src/app/shared/layout/footer/footer.html
+++ b/src/app/shared/layout/footer/footer.html
@@ -59,7 +59,9 @@
         </p>
         <div class="flex gap-4 mt-6">
           <a
-            href="https://github.com/pushserbia"
+            [href]="links.github"
+            target="_blank"
+            rel="noopener noreferrer"
             class="text-neutral-400 hover:text-white transition-colors"
             aria-label="GitHub"
           >
@@ -70,7 +72,9 @@
             </svg>
           </a>
           <a
-            href="https://www.linkedin.com/company/pushserbia"
+            [href]="links.linkedin"
+            target="_blank"
+            rel="noopener noreferrer"
             class="text-neutral-400 hover:text-white transition-colors"
             aria-label="LinkedIn"
           >
@@ -81,7 +85,9 @@
             </svg>
           </a>
           <a
-            href="https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ"
+            [href]="links.slack"
+            target="_blank"
+            rel="noopener noreferrer nofollow"
             class="text-neutral-400 hover:text-white transition-colors"
             aria-label="Slack"
           >
@@ -118,13 +124,19 @@
         </p>
         <ul class="space-y-3 text-sm text-neutral-400">
           <li>
-            <a href="https://github.com/pushserbia" class="hover:text-white transition-colors"
+            <a
+              [href]="links.github"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="hover:text-white transition-colors"
               >GitHub</a
             >
           </li>
           <li>
             <a
-              href="https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ"
+              [href]="links.slack"
+              target="_blank"
+              rel="noopener noreferrer nofollow"
               class="hover:text-white transition-colors"
               >Slack</a
             >

--- a/src/app/shared/layout/footer/footer.ts
+++ b/src/app/shared/layout/footer/footer.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/cor
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { IntegrationsApi } from '../../../core/integrations/integrations-api';
+import { EXTERNAL_LINKS } from '../../external-links';
 
 @Component({
   selector: 'app-footer',
@@ -10,6 +11,7 @@ import { IntegrationsApi } from '../../../core/integrations/integrations-api';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Footer {
+  readonly links = EXTERNAL_LINKS;
   currentYear = new Date().getFullYear();
   newsletterEmail = '';
   newsletterStatus = signal<'idle' | 'loading' | 'success' | 'error' | 'unavailable' | 'invalid'>('idle');


### PR DESCRIPTION
Slack invite links return 302 redirects, flagged by SEO audit on every
page. Centralize external URLs (Slack, GitHub, LinkedIn) into a shared
constant and add target="_blank" with rel="noopener noreferrer nofollow"
to Slack links so crawlers skip the redirect chain.

https://claude.ai/code/session_01HsYkKoxFsyynbawMRs8ffB