### PR TITLE
fix: add missing project pages to sitemap and noindex login page

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -18,6 +18,28 @@
     <priority>0.9</priority>
   </url>
 
+  <!-- Project pages -->
+  <url>
+    <loc>https://pushserbia.com/projekti/zasadi-drvo</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://pushserbia.com/projekti/udomi-ne-kupuj</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://pushserbia.com/projekti/spasi-obrok</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://pushserbia.com/projekti/popravi-umesto-baci</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
   <!-- Blog posts -->
   <url>
     <loc>https://pushserbia.com/blog/zasto-smo-pokrenuli-push-serbia</loc>

--- a/src/app/core/seo/seo-manager.ts
+++ b/src/app/core/seo/seo-manager.ts
@@ -9,6 +9,7 @@ export interface SeoConfig {
   image?: string;
   url?: string;
   type?: string;
+  robots?: string;
   jsonLd?: Record<string, unknown>;
 }
 
@@ -45,6 +46,12 @@ export class SeoManager {
     this.meta.updateTag({ name: 'twitter:title', content: title });
     this.meta.updateTag({ name: 'twitter:description', content: description });
     this.meta.updateTag({ name: 'twitter:image', content: image });
+
+    if (config.robots) {
+      this.meta.updateTag({ name: 'robots', content: config.robots });
+    } else {
+      this.meta.removeTag('name="robots"');
+    }
 
     this.updateCanonical(url);
 

--- a/src/app/features/auth/login/login.ts
+++ b/src/app/features/auth/login/login.ts
@@ -20,6 +20,7 @@ export class Login implements OnInit {
     this.seo.update({
       title: 'Prijava',
       description: 'Prijavi se na Push Serbia platformu putem LinkedIn naloga.',
+      robots: 'noindex',
     });
 
     if (isPlatformBrowser(this.platformId)) {


### PR DESCRIPTION
Add 4 project pages (zasadi-drvo, udomi-ne-kupuj, spasi-obrok,
popravi-umesto-baci) to the static sitemap so search engines index them
properly. Add robots meta tag support to SeoManager and mark the login
page as noindex since it has no valuable content for SEO.

https://claude.ai/code/session_014SuD2zZ8fBfYv9fLiG8Zw1