### PR TITLE
fix: change project structured data from SoftwareApplication to CreativeWork

### DIFF
--- a/src/app/features/projects/pages/project-details-page/project-details-page.ts
+++ b/src/app/features/projects/pages/project-details-page/project-details-page.ts
@@ -70,10 +70,13 @@ export class ProjectDetailsPage implements OnInit {
             description: project.shortDescription,
             image: project.image,
             jsonLd: {
-              '@type': 'SoftwareApplication',
+              '@type': 'CreativeWork',
               name: project.name,
               description: project.shortDescription,
               image: project.image,
+              url: `https://pushserbia.com/projekti/${project.slug}`,
+              dateCreated: project.createdAt,
+              dateModified: project.updatedAt,
               author: {
                 '@type': 'Person',
                 name: project.creator.fullName,


### PR DESCRIPTION
SoftwareApplication requires properties like offers and applicationCategory
that don't apply to community project proposals, causing Google rich results
validation errors. CreativeWork is semantically correct and adds url,
dateCreated, and dateModified for better search engine understanding.

https://claude.ai/code/session_01NCcGWFummGAGvTkxsBoxDd