### PR TITLE
fix: expand meta descriptions to 110-160 character range for better SEO

### DIFF
--- a/src/app/features/auth/login/login.ts
+++ b/src/app/features/auth/login/login.ts
@@ -19,7 +19,8 @@ export class Login implements OnInit {
   ngOnInit() {
     this.seo.update({
       title: 'Prijava',
-      description: 'Prijavi se na Push Serbia platformu putem LinkedIn naloga.',
+      description:
+        'Prijavi se na Push Serbia platformu putem svog LinkedIn naloga. Brza i jednostavna autentikacija za pristup projektima i glasanju.',
     });
 
     if (isPlatformBrowser(this.platformId)) {

--- a/src/app/features/blog/blog/blog.ts
+++ b/src/app/features/blog/blog/blog.ts
@@ -20,7 +20,8 @@ export class Blog {
   constructor() {
     this.seo.update({
       title: 'Blog',
-      description: 'Znanje, iskustva i novosti iz Push Serbia zajednice.',
+      description:
+        'Čitaj blogove Push Serbia zajednice — znanje, iskustva, novosti i priče o razvoju open-source projekata sa društvenim uticajem u Srbiji.',
     });
   }
 }

--- a/src/app/features/docs/pages/brand-center/brand-center.ts
+++ b/src/app/features/docs/pages/brand-center/brand-center.ts
@@ -16,7 +16,7 @@ export class BrandCenter {
     this.seo.update({
       title: 'Brend centar',
       description:
-        'Push Serbia brend resursi — logotip, boje, tipografija i smernice za korišćenje.',
+        'Push Serbia brend resursi — preuzmite logotip, saznajte više o bojama, tipografiji i pravilima vizuelnog identiteta naše zajednice.',
     });
   }
 }

--- a/src/app/features/docs/pages/careers/careers.ts
+++ b/src/app/features/docs/pages/careers/careers.ts
@@ -16,7 +16,7 @@ export class Careers {
     this.seo.update({
       title: 'Karijere',
       description:
-        'Pridruži se Push Serbia timu — otvorene pozicije i mogućnosti za saradnju.',
+        'Pridruži se Push Serbia timu — pogledaj otvorene pozicije, mogućnosti za saradnju i kako možeš doprineti razvoju open-source projekata.',
     });
   }
 }

--- a/src/app/features/docs/pages/contact/contact.ts
+++ b/src/app/features/docs/pages/contact/contact.ts
@@ -16,7 +16,7 @@ export class Contact {
     this.seo.update({
       title: 'Kontakt',
       description:
-        'Kontaktiraj Push Serbia tim — email, društvene mreže, Slack i GitHub.',
+        'Kontaktiraj Push Serbia tim putem email-a, društvenih mreža, Slack-a ili GitHub-a. Tu smo da odgovorimo na sva tvoja pitanja i predloge.',
     });
   }
 }

--- a/src/app/features/docs/pages/licensing/licensing.ts
+++ b/src/app/features/docs/pages/licensing/licensing.ts
@@ -16,7 +16,7 @@ export class Licensing {
     this.seo.update({
       title: 'Licence',
       description:
-        'Informacije o licencama koje koristi Push Serbia platforma i open-source projekti.',
+        'Informacije o licencama koje koristi Push Serbia platforma i open-source projekti. Saznaj više o uslovima korišćenja koda i resursa.',
     });
   }
 }

--- a/src/app/features/docs/pages/privacy-policy/privacy-policy.ts
+++ b/src/app/features/docs/pages/privacy-policy/privacy-policy.ts
@@ -16,7 +16,7 @@ export class PrivacyPolicy {
     this.seo.update({
       title: 'Politika privatnosti',
       description:
-        'Politika privatnosti Push Serbia platforme — kako prikupljamo, koristimo i štitimo vaše podatke.',
+        'Politika privatnosti Push Serbia platforme — saznajte kako prikupljamo, koristimo, čuvamo i štitimo vaše lične podatke i informacije.',
     });
   }
 }

--- a/src/app/features/docs/pages/terms/terms.ts
+++ b/src/app/features/docs/pages/terms/terms.ts
@@ -16,7 +16,7 @@ export class Terms {
     this.seo.update({
       title: 'Uslovi korišćenja',
       description:
-        'Uslovi korišćenja Push Serbia platforme — pravila i obaveze korisnika.',
+        'Uslovi korišćenja Push Serbia platforme — pravila, obaveze korisnika i smernice za korišćenje naših servisa i open-source projekata.',
     });
   }
 }

--- a/src/app/features/projects/pages/projects-list-page/projects-list-page.ts
+++ b/src/app/features/projects/pages/projects-list-page/projects-list-page.ts
@@ -63,7 +63,7 @@ export class ProjectsListPage implements OnInit {
     this.seo.update({
       title: 'Projekti',
       description:
-        'Pregledaj open-source projekte sa društvenim uticajem u Srbiji. Glasaj, predloži ili doprinesi.',
+        'Pregledaj open-source projekte sa pozitivnim društvenim uticajem u Srbiji. Glasaj za inicijative, predloži nove ideje ili doprinesi razvoju.',
     });
 
     effect(() => {


### PR DESCRIPTION
Short meta descriptions (under 110 chars) can result in poor Google snippets
and Facebook link previews. Updated 9 static page descriptions to the
recommended 110-160 character range.

https://claude.ai/code/session_016xhRbZpY5tBsyEE8Hq9mxN