### PR TITLE
fix: add nofollow to external social media links to prevent robots.txt crawl errors

### DIFF
--- a/src/app/features/docs/pages/contact/contact.html
+++ b/src/app/features/docs/pages/contact/contact.html
@@ -59,18 +59,24 @@
           <div class="flex space-x-4">
             <a
               href="https://www.facebook.com/pushserbia"
+              target="_blank"
+              rel="nofollow noopener noreferrer"
               class="text-neutral-400 hover:text-white"
             >
               Facebook
             </a>
             <a
               href="https://www.instagram.com/pushserbia"
+              target="_blank"
+              rel="nofollow noopener noreferrer"
               class="text-neutral-400 hover:text-white"
             >
               Instagram
             </a>
             <a
               href="https://www.linkedin.com/company/pushserbia"
+              target="_blank"
+              rel="nofollow noopener noreferrer"
               class="text-neutral-400 hover:text-white"
             >
               LinkedIn
@@ -103,6 +109,8 @@
           </p>
           <a
             href="https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
             class="inline-flex items-center text-primary-400 hover:text-primary-300 font-medium"
           >
             Pridruži se Slack serveru
@@ -118,6 +126,8 @@
           </p>
           <a
             href="https://github.com/pushserbia"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
             class="inline-flex items-center text-primary-400 hover:text-primary-300 font-medium"
           >
             Poseti GitHub organizaciju

--- a/src/app/features/landing/sections/landing-hero/landing-hero.html
+++ b/src/app/features/landing/sections/landing-hero/landing-hero.html
@@ -39,7 +39,7 @@
               [title]="member.name"
               [href]="member.linkedinUrl"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="nofollow noopener noreferrer"
               class="rounded-full border-2 border-black overflow-hidden hover:scale-110 hover:z-10 transition-transform w-9 h-9"
             >
               <img [ngSrc]="member.imageUrl" [alt]="member.name" width="36" height="36" priority />

--- a/src/app/shared/layout/footer/footer.html
+++ b/src/app/shared/layout/footer/footer.html
@@ -60,6 +60,8 @@
         <div class="flex gap-4 mt-6">
           <a
             href="https://github.com/pushserbia"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
             class="text-neutral-400 hover:text-white transition-colors"
             aria-label="GitHub"
           >
@@ -71,6 +73,8 @@
           </a>
           <a
             href="https://www.linkedin.com/company/pushserbia"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
             class="text-neutral-400 hover:text-white transition-colors"
             aria-label="LinkedIn"
           >
@@ -82,6 +86,8 @@
           </a>
           <a
             href="https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
             class="text-neutral-400 hover:text-white transition-colors"
             aria-label="Slack"
           >
@@ -118,13 +124,15 @@
         </p>
         <ul class="space-y-3 text-sm text-neutral-400">
           <li>
-            <a href="https://github.com/pushserbia" class="hover:text-white transition-colors"
+            <a href="https://github.com/pushserbia" target="_blank" rel="nofollow noopener noreferrer" class="hover:text-white transition-colors"
               >GitHub</a
             >
           </li>
           <li>
             <a
               href="https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ"
+              target="_blank"
+              rel="nofollow noopener noreferrer"
               class="hover:text-white transition-colors"
               >Slack</a
             >


### PR DESCRIPTION
LinkedIn and Instagram block SEO crawlers via their robots.txt, causing
"Blocked by robots.txt" warnings. Adding rel="nofollow noopener noreferrer"
and target="_blank" to all external social media links in the footer,
contact page, and landing hero.

https://claude.ai/code/session_01PmjhBEFM4HVACRnQEZkP5w