### PR TITLE
fix: route Slack invite through internal 301 redirect

### DIFF
--- a/src/app/shared/external-links.ts
+++ b/src/app/shared/external-links.ts
@@ -1,6 +1,8 @@
+export const SLACK_INVITE_URL =
+  'https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ';
+
 export const EXTERNAL_LINKS = {
-  slack:
-    'https://join.slack.com/t/pushserbia/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ',
+  slack: '/pridruzi-se-slack',
   github: 'https://github.com/pushserbia',
   linkedin: 'https://www.linkedin.com/company/pushserbia',
 } as const;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,12 +7,17 @@ import {
 import express from 'express';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { SLACK_INVITE_URL } from './app/shared/external-links';
 
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
 
 export const app = express();
 const angularApp = new AngularNodeAppEngine();
+
+app.get('/pridruzi-se-slack', (_req, res) => {
+  res.redirect(301, SLACK_INVITE_URL);
+});
 
 /**
  * Example Express Rest API endpoints can be defined here.


### PR DESCRIPTION
SEO audit flagged the Slack shared_invite URL as an external 302
redirect on every page that links to it (homepage, blog posts, project
pages, contact). Slack's invite flow inherently redirects, so there is
no non-redirecting destination to link to directly.

Convert the external redirect into an internal one by adding an Express
route at /pridruzi-se-slack that issues a 301 to the Slack URL, and
point EXTERNAL_LINKS.slack at the internal path. The audit explicitly
states internal redirects are not a problem, and this also centralizes
the invite URL so rotations can be handled in one place.

https://claude.ai/code/session_01Wcr6kqM24VXZZtEW9SrzJ3