### PR TITLE
fix: expand blog post excerpts to meet 110-160 char meta description range

### DIFF
--- a/src/app/core/blog/blog-store.ts
+++ b/src/app/core/blog/blog-store.ts
@@ -144,7 +144,7 @@ export class BlogStore {
       author: 'Push Serbia tim',
       date: '2026-02-28',
       excerpt:
-        'Šta smo naučili, gde smo pogrešili i šta bismo uradili drugačije da krenemo iz početka.',
+        'Iskrena refleksija o prvoj godini Push Serbia zajednice — šta smo naučili, gde smo pogrešili i šta bismo uradili drugačije da krenemo iz početka.',
       content: `
         <p>Prošla je godina od pokretanja Push Serbia. Vreme za iskren pogled unazad — bez ulepšavanja.</p>
 
@@ -214,7 +214,7 @@ export class BlogStore {
       author: 'Push Serbia tim',
       date: '2026-03-15',
       excerpt:
-        'Pogled iznutra na alate, rituale i principe koji pokreću razvoj naših open-source projekata.',
+        'Pogled iznutra na alate, rituale i principe koji pokreću razvoj naših open-source projekata — bez birokratije i korporativnih procesa.',
       content: `
         <p>Jedno od pitanja koje najčešće čujemo od novih članova: "OK, pridružio sam se. Šta sad?" Fer pitanje. Evo kako zapravo izgleda rad na projektu u Push Serbia zajednici.</p>
 


### PR DESCRIPTION
Extends excerpts for two blog posts whose meta descriptions were flagged
as too short in SEO crawl (5-lekcija-iz-prve-godine at 87 chars,
kako-organizujemo-rad-na-projektima at 92 chars). The excerpt is reused
as the meta description in BlogPostDetails.

https://claude.ai/code/session_01NuWgCjT6ePqGZ6v6A8TFFA