### PR TITLE
fix: lengthen home page title to improve SEO

### DIFF
--- a/src/app/features/landing/landing.ts
+++ b/src/app/features/landing/landing.ts
@@ -29,6 +29,7 @@ export class Landing {
 
   constructor() {
     this.seo.update({
+      title: 'Open-source zajednica za društveno korisne projekte',
       url: 'https://pushserbia.com',
     });
   }

--- a/src/indexFile.html
+++ b/src/indexFile.html
@@ -36,7 +36,7 @@
     />
     <meta name="twitter:image" content="https://pushserbia.com/pushserbia.png" />
     <meta name="twitter:site" content="@PushSerbia" />
-    <title>Push Serbia</title>
+    <title>Push Serbia - Open-source zajednica za društveno korisne projekte</title>
     <base href="/" />
     <link rel="icon" type="image/x-icon" href="favicon.ico?v=2" />
     <link rel="canonical" href="https://pushserbia.com" />


### PR DESCRIPTION
The landing page was setting the document title to just "Push Serbia"
(11 chars), below the 50–70 char range recommended for SERP. Pass a
descriptive Serbian tagline so SeoManager renders
"Open-source zajednica za društveno korisne projekte | Push Serbia"
(~65 chars). Also update the static indexFile.html fallback for
consistency before hydration.

https://claude.ai/code/session_01FmLHH4gSaVsP3hz8jRQawZ