### PR TITLE
fix: add Brend centar footer link to resolve orphan page

### DIFF
--- a/src/app/shared/layout/footer/footer.html
+++ b/src/app/shared/layout/footer/footer.html
@@ -147,6 +147,11 @@
             >
           </li>
           <li>
+            <a routerLink="/dokumentacija/brend-centar" class="hover:text-white transition-colors"
+              >Brend centar</a
+            >
+          </li>
+          <li>
             <a routerLink="/placanja/finansiranje" class="hover:text-white transition-colors"
               >Podrži nas</a
             >


### PR DESCRIPTION
The /dokumentacija/brend-centar page had no incoming internal links,
making it discoverable only via sitemap. Added a link in the footer's
Zajednica section alongside other community documentation.