### PR TITLE
Fix vercel.json schema validation error: remove invalid 'public' property

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
-  "public": true,
   "name": "pushserbia-fe",
   "buildCommand": "npm run build",
   "rewrites": [


### PR DESCRIPTION
## Summary

- Removed the `"public": true` property from `vercel.json`, which is not a valid field in the Vercel v2 configuration schema and was causing schema validation to fail with: `should NOT have additional property 'public'`

---
_Generated by [Claude Code](https://claude.ai/code/session_01As5iu9dkFXGgKApFB5ihLn)_