### PR TITLE
fix(seo): resolve Ahrefs technical SEO audit findings

### DIFF
--- a/src/app/core/seo/seo-manager.ts
+++ b/src/app/core/seo/seo-manager.ts
@@ -47,7 +47,13 @@ export class SeoManager {
   private readonly router = inject(Router);
 
   update(config: SeoConfig): void {
-    const title = config.title ? `${config.title} | ${SITE_NAME}` : SITE_NAME;
+    // Append the site name as a suffix, unless the page already leads with the
+    // brand (e.g. the home page) — that avoids a duplicated "Push Serbia".
+    const title = config.title
+      ? config.title.includes(SITE_NAME)
+        ? config.title
+        : `${config.title} | ${SITE_NAME}`
+      : SITE_NAME;
     const description = config.description || DEFAULT_DESCRIPTION;
     const image = config.image || DEFAULT_IMAGE;
     const cleanPath = this.router.url.split('?')[0].split('#')[0];

--- a/src/app/features/auth/login/login.ts
+++ b/src/app/features/auth/login/login.ts
@@ -21,7 +21,10 @@ export class Login implements OnInit {
       title: 'Prijava',
       description:
         'Prijavi se na Push Serbia platformu putem svog LinkedIn naloga. Brza i jednostavna autentikacija za pristup projektima i glasanju.',
-      robots: 'noindex',
+      // The login page is intentionally kept out of the index (no public search
+      // value). Pair `noindex` with `nofollow` so the directives are consistent
+      // — Google treats a long-lived `noindex` as `noindex, nofollow` anyway.
+      robots: 'noindex, nofollow',
     });
 
     if (isPlatformBrowser(this.platformId)) {

--- a/src/app/features/blog/blog-post-details/blog-post-details.html
+++ b/src/app/features/blog/blog-post-details/blog-post-details.html
@@ -56,6 +56,40 @@
             </a>
           </div>
         </article>
+
+        @if (relatedPosts.length > 0) {
+          <section class="mt-16 pt-8 border-t border-white/5">
+            <h2 class="font-mono text-xl font-bold text-white mb-6">Srodni članci</h2>
+            <div class="grid gap-6 sm:grid-cols-3">
+              @for (related of relatedPosts; track related.id) {
+                <a
+                  [routerLink]="['/blog', related.slug]"
+                  class="group rounded-xl border border-white/5 bg-neutral-950 overflow-hidden hover:border-white/10 transition-colors"
+                >
+                  @if (related.image) {
+                    <div class="overflow-hidden">
+                      <img
+                        [src]="related.image"
+                        [alt]="related.title"
+                        width="1470"
+                        height="980"
+                        class="w-full h-32 object-cover group-hover:scale-105 transition-transform duration-500"
+                      />
+                    </div>
+                  }
+                  <div class="p-4">
+                    <span class="block text-xs text-neutral-400 mb-2">{{ related.date }}</span>
+                    <h3
+                      class="text-sm font-bold text-white group-hover:text-primary-400 transition-colors line-clamp-2"
+                    >
+                      {{ related.title }}
+                    </h3>
+                  </div>
+                </a>
+              }
+            </div>
+          </section>
+        }
       } @else {
         <div class="p-8 bg-neutral-950 rounded-xl border border-white/5 text-center">
           <p class="text-neutral-400 mb-4">Članak nije pronađen.</p>

--- a/src/app/features/blog/blog-post-details/blog-post-details.spec.ts
+++ b/src/app/features/blog/blog-post-details/blog-post-details.spec.ts
@@ -33,6 +33,7 @@ describe('BlogPostDetails', () => {
   beforeEach(async () => {
     blogStoreMock = {
       getBlogPostBySlug: vi.fn(),
+      getBlogPosts: vi.fn().mockReturnValue([mockBlogPost]),
     } as unknown as BlogStore;
     seoManagerMock = {
       update: vi.fn(),

--- a/src/app/features/blog/blog-post-details/blog-post-details.ts
+++ b/src/app/features/blog/blog-post-details/blog-post-details.ts
@@ -27,11 +27,14 @@ export class BlogPostDetails implements OnInit {
 
   readonly slug = input.required<string>();
   post: BlogPost | undefined;
+  relatedPosts: BlogPost[] = [];
 
   ngOnInit() {
     this.post = this.blogStoreService.getBlogPostBySlug(this.slug());
 
     if (this.post) {
+      this.relatedPosts = this.getRelatedPosts(this.post);
+
       this.seo.update({
         title: this.post.title,
         description: this.post.excerpt,
@@ -66,5 +69,24 @@ export class BlogPostDetails implements OnInit {
         this.response.status = 404;
       }
     }
+  }
+
+  /**
+   * Pick up to three other posts to surface as "Srodni članci". Posts sharing
+   * the most tags rank first, falling back to chronological order. These render
+   * as plain dofollow internal links so every post receives inbound links from
+   * its siblings, not just the single link from the blog listing page.
+   */
+  private getRelatedPosts(current: BlogPost): BlogPost[] {
+    return this.blogStoreService
+      .getBlogPosts()
+      .filter((post) => post.slug !== current.slug)
+      .map((post) => ({
+        post,
+        sharedTags: post.tags?.filter((tag) => current.tags?.includes(tag)).length ?? 0,
+      }))
+      .sort((a, b) => b.sharedTags - a.sharedTags)
+      .slice(0, 3)
+      .map((entry) => entry.post);
   }
 }

--- a/src/app/features/landing/landing.ts
+++ b/src/app/features/landing/landing.ts
@@ -28,8 +28,12 @@ export class Landing {
   private readonly seo = inject(SeoManager);
 
   constructor() {
+    // Brand-forward, concise home page title (≈49 chars). Google was ignoring
+    // the previous generic, keyword-led title ("Open-source zajednica za...")
+    // and rewriting the SERP title down to just "Push Serbia". Leading with the
+    // brand and a specific value proposition gives Google a title it can use.
     this.seo.update({
-      title: 'Open-source zajednica za društveno korisne projekte',
+      title: 'Push Serbia — open-source projekti za opšte dobro',
       url: 'https://pushserbia.com',
     });
   }

--- a/src/app/features/projects/pages/project-details-page/project-details-page.html
+++ b/src/app/features/projects/pages/project-details-page/project-details-page.html
@@ -142,6 +142,29 @@
             [creatorId]="projectDetails.creator.id"
             [currentUser]="$currentUser()"
           />
+
+          @if ($relatedProjects().length > 0) {
+            <div class="w-full pt-8 border-t border-white/5">
+              <h2 class="text-xl font-bold text-white mb-6">Drugi projekti</h2>
+              <div class="grid gap-4 sm:grid-cols-3">
+                @for (related of $relatedProjects(); track related.slug) {
+                  <a
+                    [routerLink]="['/projekti', related.slug]"
+                    class="group block p-4 rounded-xl border border-white/5 bg-neutral-900 hover:border-white/10 transition-colors"
+                  >
+                    <h3
+                      class="text-sm font-bold text-white group-hover:text-primary-400 transition-colors line-clamp-2"
+                    >
+                      {{ related.name }}
+                    </h3>
+                    <p class="mt-2 text-xs text-neutral-400 line-clamp-2">
+                      {{ related.shortDescription }}
+                    </p>
+                  </a>
+                }
+              </div>
+            </div>
+          }
         </div>
       } @else {
         <div class="w-full max-w-screen-xl mx-auto px-4 py-16 text-center">

--- a/src/app/features/projects/pages/project-details-page/project-details-page.spec.ts
+++ b/src/app/features/projects/pages/project-details-page/project-details-page.spec.ts
@@ -34,6 +34,7 @@ describe('ProjectDetailsPage', () => {
   beforeEach(async () => {
     mockProjectStore = {
       getBySlug: vi.fn().mockReturnValue(signal(mockProject as any)),
+      getAll: vi.fn().mockReturnValue(signal([mockProject] as any)),
       updateStateBySlug: vi.fn(),
       $loading: signal(false),
     } as any;

--- a/src/app/features/projects/pages/project-details-page/project-details-page.ts
+++ b/src/app/features/projects/pages/project-details-page/project-details-page.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   effect,
   inject,
   Injector,
@@ -60,6 +61,17 @@ export class ProjectDetailsPage implements OnInit {
   $voted?: Signal<boolean>;
 
   $currentUser = this.authService.$userData;
+
+  // Up to three other projects, surfaced as dofollow internal links so each
+  // project receives inbound links from its siblings — not only the single
+  // link from the /projekti listing page.
+  private readonly $allProjects = this.projectStore.getAll();
+  readonly $relatedProjects = computed<Project[]>(() => {
+    const current = this.$project?.();
+    return this.$allProjects()
+      .filter((project) => project?.slug && project.slug !== current?.slug)
+      .slice(0, 3);
+  });
 
   ngOnInit(): void {
     this.$project = this.projectStore.getBySlug(this.slug());

--- a/src/app/shared/external-links.ts
+++ b/src/app/shared/external-links.ts
@@ -4,7 +4,12 @@ export const SLACK_INVITE_URL =
   'https://pushserbia.slack.com/join/shared_invite/zt-34h9oiyc4-w8eLTnI9f5I6EbTueg8HWQ';
 
 export const EXTERNAL_LINKS = {
-  slack: '/pridruzi-se-slack',
+  // Link straight to the Slack workspace instead of the internal
+  // `/pridruzi-se-slack` route. The internal route only 301-redirects here, so
+  // pointing at it from navigation/footer created "links to redirect" and
+  // "nofollow internal link" SEO warnings on every page. Linking directly to
+  // the external destination removes the redirect hop entirely.
+  slack: SLACK_INVITE_URL,
   github: 'https://github.com/pushserbia',
   linkedin: 'https://www.linkedin.com/company/pushserbia',
 } as const;


### PR DESCRIPTION
## Summary

Addresses the technical SEO issues from the Ahrefs Site Audit that are fixable in the frontend. The app is Angular 21 + SSR (Express), so SEO tags are driven through `SeoManager` (the `Meta`/`Title` services) rather than a `<Head>`/Metadata API.

## Changes

### Slack link → removes redirect + nofollow-internal warnings (Greška 6, 7, 9)
`EXTERNAL_LINKS.slack` now points directly to the external Slack workspace invite (`SLACK_INVITE_URL`) instead of the internal `/pridruzi-se-slack` route. That internal route only `301`-redirects to Slack, so referencing it from the footer/contact created **"Page has links to redirect"**, **"nofollow outgoing internal link"** and a **3XX redirect** with 15 inlinks on every page. Linking straight to the destination removes the hop. The `server.ts` redirect route is kept as a fallback for old bookmarks (it no longer has internal inlinks). `rel="nofollow"` on these now-external links is appropriate and harmless.

### Home page title (Greška 3)
Changed the generic, keyword-led title to a brand-forward, specific one: **"Push Serbia — open-source projekti za opšte dobro"** (~49 chars). Google was ignoring the previous title and rewriting the SERP title down to just "Push Serbia". `SeoManager` now skips the `| Push Serbia` suffix when a title already includes the brand, to avoid duplication.

### Login page robots (Greška 4, 5)
The login page is intentionally `noindex` (no public search value). Paired it with `nofollow` (`noindex, nofollow`) for consistent directives — Google treats a long-lived `noindex` as `noindex, nofollow` anyway.

### Internal cross-linking (Greška 8)
Added **"Srodni članci"** to blog post pages and **"Drugi projekti"** to project detail pages — up to three sibling links each, as plain dofollow internal `routerLink`s. Previously each blog/project page received only the single inbound link from its listing page; now each page gets several. Blog related posts are ranked by shared tags.

## Already handled / out of frontend scope

- **HTTP→HTTPS & www canonicalization (Greška 9, 10, 11):** `server.ts` already redirects `www`→non-www and `http`→`https` in a single 301 hop, scoped to the production host. The remaining `http://www` two-hop is Vercel's edge `308` (http→https), which is platform-level and not removable in app code. No internal `http://` links exist in the codebase.
- **Meta description length (Greška 1, 2):** Project meta descriptions come from `project.shortDescription` (backend/API data), not this repo. The create-project form already validates 110–160 characters for new projects; the flagged legacy descriptions (`popravi-umesto-baci`, `spasi-obrok`, `zasadi-drvo`) need updating in the backend data, not the frontend.

## Testing

- `ng test` — 528 passed (updated 2 spec mocks to provide `getAll`/`getBlogPosts`)
- `ng build --configuration lighthouse` — AOT build succeeds
- `ng lint` — no new errors introduced (pre-existing `no-explicit-any` debt in spec files is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0121mxuoMTNjBNzqY53TyJmz)_